### PR TITLE
updated depositAndStake Fetch event

### DIFF
--- a/src/openStaking.ts
+++ b/src/openStaking.ts
@@ -37,13 +37,11 @@ export async function getUniqueStakersFromOpenStaking(
         existingSnapshot ? existingSnapshot.uniqueStakers : []
     );
 
-    // Convert block identifiers to actual block numbers
     const currentBlockNumber = await web3Instance.eth.getBlockNumber();
     const resolvedFromBlock = fromBlock === "latest" ? currentBlockNumber : fromBlock;
     const resolvedToBlock = toBlock === "latest" ? currentBlockNumber : toBlock;
 
     const step = blockIterationSize;
-
     let startBlock = resolvedFromBlock;
     if (existingSnapshot && existingSnapshot.latestBlockCaptured >= resolvedFromBlock) {
         startBlock = existingSnapshot.latestBlockCaptured + 1;
@@ -62,37 +60,16 @@ export async function getUniqueStakersFromOpenStaking(
             topics: [transferEventSignature, null, web3Instance.eth.abi.encodeParameter("address", stakingContractAddress)],
         };
 
-
         try {
             const logs = await web3Instance.eth.getPastLogs(transferEventFilter);
-            console.log("Fetched logs:", logs);
 
-            logs.forEach((log) => {
-                console.log("Log:", log);
+            for (const log of logs) {
+                const transactionReceipt = await web3Instance.eth.getTransactionReceipt(log.transactionHash);
+                const transactionSender = transactionReceipt.from.toLowerCase();
 
-                const eventInterface = tokenContract.options.jsonInterface.find(
-                    (i: any) => i.signature === log.topics[0]
-                );
-
-                if (!eventInterface) {
-                    console.error("Event interface not found for signature:", log.topics[0]);
-                    return;
-                }
-
-                const inputs = eventInterface.inputs as AbiInput[];
-
-                const event = web3Instance.eth.abi.decodeLog(
-                    inputs,
-                    log.data,
-                    log.topics.slice(1)
-                );
-                console.log("Decoded event:", event);
-
-                // Check if the destination address matches the staking contract address
-                if (event.dst.toLowerCase() === stakingContractAddress.toLowerCase()) {
-                    uniqueStakers.add(event.src.toLowerCase());
-                }
-            });
+                // Add the transaction sender to the set of unique stakers
+                uniqueStakers.add(transactionSender);
+            }
 
             console.log("Unique stakers fetched for blocks", currentBlock, "to", endBlock);
             await saveStakingSnapshot(
@@ -114,6 +91,7 @@ export async function getUniqueStakersFromOpenStaking(
 
     return uniqueStakers;
 }
+
 
 export async function getOpenStakingStakedBalances(
     stakingPoolName: string,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -73,14 +73,14 @@ export const processStakingContractDataItem = async (
                 DB_COLLECTION_STAKING_SNAPSHOT!,
                 DB_CONNECTION_STRING!
             );
-            console.log("Staked balances:", stakedBalances);
+            // console.log("Staked balances:", stakedBalances);
 
             const result = {
                 stakingPoolName: stakingPoolName,
                 stakedBalances: stakedBalances,
             };
 
-            console.log("Result:", JSON.stringify(result, null, 2));
+            // console.log("Result:", JSON.stringify(result, null, 2));
 
             // Update the totalStakedBalances object
             updateTotalStakedBalances(stakedBalances, totalStakedBalances);
@@ -102,7 +102,7 @@ export const processStakingContractDataItem = async (
                 DB_COLLECTION_STAKING_SNAPSHOT!,
                 DB_CONNECTION_STRING!
             );
-            console.log("Unique staker addresses from open staking:", uniqueStakers);
+            // console.log("Unique staker addresses from open staking:", uniqueStakers);
 
             const stakedBalances = await getOpenStakingStakedBalances(
                 stakingPoolName,
@@ -116,14 +116,14 @@ export const processStakingContractDataItem = async (
                 DB_COLLECTION_STAKING_SNAPSHOT!,
                 DB_CONNECTION_STRING!
             );
-            console.log("Staked balances from open staking:", stakedBalances);
+            // console.log("Staked balances from open staking:", stakedBalances);
 
             const result = {
                 stakingPoolName: stakingPoolName,
                 stakedBalances: stakedBalances,
             };
 
-            console.log("Result:", JSON.stringify(result, null, 2));
+            // console.log("Result:", JSON.stringify(result, null, 2));
 
             // Update the totalStakedBalances object
             updateTotalStakedBalances(stakedBalances, totalStakedBalances);
@@ -141,7 +141,7 @@ export const processStakingContractDataItem = async (
     // Add the total staked balances to the finalResults array
     finalResults.push({ stakingPoolName: "totalStakedBalances", stakedBalances: totalStakedBalances });
 
-    console.log("Final Results:", JSON.stringify(finalResults, null, 2));
+    // console.log("Final Results:", JSON.stringify(finalResults, null, 2));
 
     return finalResults;
 };


### PR DESCRIPTION
## Overview
This release introduces a significant update to the `getUniqueStakersFromOpenStaking` function in the Snap-HODL dApp. The update enhances the accuracy of identifying unique stakers by considering the transaction initiator's address instead of the source address in the event log. This solves the issue of Mint and Stake users utilizing the "Deposit and Stake" function where the cFRM is minted and sent to the staking addresses from the genesis 0x000 address.

## Changes
### Updated Functionality
- **getUniqueStakersFromOpenStaking**: Modified to capture the address of the transaction initiator for each staking-related event. This change ensures that the list of unique stakers is more accurately represented, especially in scenarios where the source address in the event log does not reflect the actual staker's address.

### Technical Improvements
- Implemented asynchronous loop handling within `getUniqueStakersFromOpenStaking` to fetch transaction receipts.
- Enhanced error handling for transaction receipt fetching and processing.

## Bug Fixes
- Fixed an issue where certain staking transactions were not correctly attributed to the initiating staker.
