### PR TITLE
TotalTradingVolume Type Error Fixed

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -513,6 +513,9 @@ export const getSnapHodlConfigTradingVolumeBalance = async (
             if(!minimumTradingBalance || minimumTradingBalance === 0 || balanceBN.isGreaterThanOrEqualTo(minimumTradingBalance)){
               totalBalance = totalBalance.plus(balanceBN);
               if (totalTradingVolume[address]) {
+                if(typeof totalTradingVolume[address] === "string" || totalTradingVolume[address] instanceof String){
+                  totalTradingVolume[address] = new BigNumber(totalTradingVolume[address]);
+                }
                 totalTradingVolume[address] =
                   totalTradingVolume[address].plus(balanceBN);
               } else {


### PR DESCRIPTION
**Title:** Fix Type Handling for Total Trading Volume

**Description:**

Fixed an issue where `totalTradingVolume` values of type string were not being properly converted to `BigNumber` objects, potentially causing errors in calculations. Added a check to convert string values to `BigNumber` for consistent handling.
